### PR TITLE
Add deploy action

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "checkhaebang"
+  }
+}

--- a/.github/deploy.yml
+++ b/.github/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - master
 
@@ -21,6 +22,7 @@ jobs:
           name: build
           path: build
   deploy:
+    if: github.event.pull_request.merged == true
     name: Deploy
     needs: build
     runs-on: ubuntu-latest

--- a/.github/deploy.yml
+++ b/.github/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Install Dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Archive Production Artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: build
+          path: build
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Download Artifact
+        uses: actions/download-artifact@master
+        with:
+          name: build
+          path: build
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@v1.5.0
+        with:
+          args: deploy --only hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "build",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# CI: Firebase - GitHub Integration
GitHub Action을 활용해 master에 merge가 일어날 때 마다 Firebase Hosting으로 React build를 배포하도록 설정합니다.

## 진행내용
### Initializing Firebase
`firebase init`을 통해 Firebase에 생성된 `checkhaebang`이라는 hosting project에 배포될 수 있도록 설정을 추가했습니다.
- `firebase.json` 추가
- `.firebaserc` 추가

### Creating GitHub Action
`deploy.yml`을 추가하여 master에 PR이 merge 되면 build가 진행되고 Firebase Hosting으로 배포되도록 설정했습니다.
- GitHub marketplace에서 `GitHub Actions for Firebase` 사용
- repository에 environment variable로 "FIREBASE_TOKEN" 추가

<img width="500" alt="스크린샷 2020-07-14 오후 11 46 21" src="https://user-images.githubusercontent.com/33085082/87439859-3ba8cb80-c62c-11ea-98e4-a5f1c2180a9b.png">

## Ref
[GitHub Actions for Firebase](https://github.com/marketplace/actions/github-action-for-firebase)
[Deploy to Firebase Hosting with Github Actions](https://medium.com/@puuga/deploy-to-firebase-hosting-with-github-actions-f795785fde6b)