### PR TITLE
Question page api

### DIFF
--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -28,6 +28,7 @@ interface IconProps {
   iconLayoutStyle?: FlattenSimpleInterpolation;
   className?: string;
   size?: string;
+  opacity?: string;
 }
 
 export default function Icon({
@@ -36,9 +37,14 @@ export default function Icon({
   iconLayoutStyle,
   className,
   size,
+  opacity,
 }: IconProps): ReactElement {
   return (
-    <S.Container className={className} iconLayoutStyle={iconLayoutStyle} size={size}>
+    <S.Container
+      className={className}
+      iconLayoutStyle={iconLayoutStyle}
+      size={size}
+      opacity={opacity}>
       {label && <S.IconLabel>{label}</S.IconLabel>}
       <img src={Icons[name]} />
     </S.Container>

--- a/src/components/icon/styled.ts
+++ b/src/components/icon/styled.ts
@@ -1,11 +1,16 @@
 import styled, { FlattenSimpleInterpolation } from 'styled-components';
 
-const Container = styled.span<{ iconLayoutStyle?: FlattenSimpleInterpolation; size?: string }>`
+const Container = styled.span<{
+  iconLayoutStyle?: FlattenSimpleInterpolation;
+  size?: string;
+  opacity?: string;
+}>`
   display: inline-block;
   vertical-align: middle;
   img {
     display: block;
     ${({ size }) => size && `width: ${size}px; height: ${size}px;`}
+    ${({ opacity }) => opacity && `opacity: ${opacity};`}
     fill: currentColor;
     flex-shrink: 0;
     user-select: none;

--- a/src/entity/persona.ts
+++ b/src/entity/persona.ts
@@ -5,10 +5,6 @@ export interface PersonaUserChoice {
   choice_id: number;
 }
 
-export interface Questions {
-  questions: PersonaQuestion[];
-}
-
 export interface PersonaQuestion {
   uid: number;
   title: string;

--- a/src/entity/persona.ts
+++ b/src/entity/persona.ts
@@ -5,6 +5,10 @@ export interface PersonaUserChoice {
   choice_id: number;
 }
 
+export interface Questions {
+  questions: PersonaQuestion[];
+}
+
 export interface PersonaQuestion {
   uid: number;
   title: string;

--- a/src/entity/persona.ts
+++ b/src/entity/persona.ts
@@ -27,3 +27,7 @@ export interface Persona {
   title: string;
   description: string;
 }
+
+export interface Viewer {
+  count: number;
+}

--- a/src/entity/response.ts
+++ b/src/entity/response.ts
@@ -1,3 +1,4 @@
+import { PersonaQuestion } from './persona';
 import { Room } from './rooms';
 
 export interface Response<T = object> {
@@ -8,4 +9,8 @@ export interface Response<T = object> {
 
 export interface RoomsResponse {
   rooms: Room[];
+}
+
+export interface QuestionsResponse {
+  questions: PersonaQuestion[];
 }

--- a/src/pages/persona/PersonaAnalysis.tsx
+++ b/src/pages/persona/PersonaAnalysis.tsx
@@ -1,4 +1,3 @@
-import request from 'api/request';
 import { Viewer } from 'entity/persona';
 import { useFetch } from 'hooks';
 import React, { ReactElement } from 'react';
@@ -14,7 +13,7 @@ enum TEXT {
 }
 
 export default function PersonaAnalysisPage(): ReactElement {
-  const { data, error, loading } = useFetch<Viewer>('/persona/count');
+  const { data } = useFetch<Viewer>('/persona/count');
   const countWithComma = data ? data.count.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : 0;
 
   const sortedTitle = TEXT.TITLE.split('\n').map((line) => {

--- a/src/pages/persona/PersonaAnalysis.tsx
+++ b/src/pages/persona/PersonaAnalysis.tsx
@@ -15,13 +15,12 @@ enum TEXT {
 export default function PersonaAnalysisPage(): ReactElement {
   const [viewerCount, setViewerCount] = useState<string>('');
 
-  const fetchViewer = async () => {
-    const res = await request.get<Viewer>('/persona/count');
-    const countWithComma = res.data.count.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    setViewerCount(countWithComma);
-  };
-
   useEffect(() => {
+    const fetchViewer = async () => {
+      const res = await request.get<Viewer>('/persona/count');
+      const countWithComma = res.data.count.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+      setViewerCount(countWithComma);
+    };
     fetchViewer();
   }, []);
 

--- a/src/pages/persona/PersonaAnalysis.tsx
+++ b/src/pages/persona/PersonaAnalysis.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement, useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import request from 'api/request';
+import { Viewer } from 'entity/persona';
+import React, { ReactElement, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import * as S from './styled';
 
@@ -11,12 +13,17 @@ enum TEXT {
 }
 
 export default function PersonaAnalysisPage(): ReactElement {
-  const [viewerCount] = useState(0);
-  const history = useHistory();
+  const [viewerCount, setViewerCount] = useState<string>('');
 
-  const handleBackButton = () => {
-    history.goBack();
+  const fetchViewer = async () => {
+    const res = await request.get<Viewer>('/persona/count');
+    const countWithComma = res.data.count.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    setViewerCount(countWithComma);
   };
+
+  useEffect(() => {
+    fetchViewer();
+  }, []);
 
   const sortedTitle = TEXT.TITLE.split('\n').map((line) => {
     return (

--- a/src/pages/persona/PersonaAnalysis.tsx
+++ b/src/pages/persona/PersonaAnalysis.tsx
@@ -48,7 +48,9 @@ export default function PersonaAnalysisPage(): ReactElement {
       <Link to='/persona/question'>
         <S.StartButton>{TEXT.START}</S.StartButton>
       </Link>
-      <S.BackButton onClick={handleBackButton}>{TEXT.BACK}</S.BackButton>
+      <Link to='/auth'>
+        <S.BackButton>{TEXT.BACK}</S.BackButton>
+      </Link>
     </S.Container>
   );
 }

--- a/src/pages/persona/PersonaAnalysis.tsx
+++ b/src/pages/persona/PersonaAnalysis.tsx
@@ -1,7 +1,7 @@
 import request from 'api/request';
 import { Viewer } from 'entity/persona';
 import React, { ReactElement, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import * as S from './styled';
 
@@ -43,6 +43,14 @@ export default function PersonaAnalysisPage(): ReactElement {
     );
   });
 
+  const history = useHistory();
+  const handleStartButtonClick = () => {
+    history.push('/persona/question');
+  };
+  const handleBackButtonClick = () => {
+    history.push('/auth');
+  };
+
   return (
     <S.Container>
       <S.Title>{sortedTitle}</S.Title>
@@ -52,12 +60,8 @@ export default function PersonaAnalysisPage(): ReactElement {
         총 <S.Count>{viewerCount}</S.Count>명이 체크해방을 참고했습니다.
       </S.CounterDescription>
 
-      <Link to='/persona/question'>
-        <S.StartButton>{TEXT.START}</S.StartButton>
-      </Link>
-      <Link to='/auth'>
-        <S.BackButton>{TEXT.BACK}</S.BackButton>
-      </Link>
+      <S.StartButton onClick={handleStartButtonClick}>{TEXT.START}</S.StartButton>
+      <S.BackButton onClick={handleBackButtonClick}>{TEXT.BACK}</S.BackButton>
     </S.Container>
   );
 }

--- a/src/pages/persona/PersonaAnalysis.tsx
+++ b/src/pages/persona/PersonaAnalysis.tsx
@@ -1,6 +1,7 @@
 import request from 'api/request';
 import { Viewer } from 'entity/persona';
-import React, { ReactElement, useEffect, useState } from 'react';
+import { useFetch } from 'hooks';
+import React, { ReactElement } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import * as S from './styled';
@@ -13,16 +14,8 @@ enum TEXT {
 }
 
 export default function PersonaAnalysisPage(): ReactElement {
-  const [viewerCount, setViewerCount] = useState<string>('');
-
-  useEffect(() => {
-    const fetchViewer = async () => {
-      const res = await request.get<Viewer>('/persona/count');
-      const countWithComma = res.data.count.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-      setViewerCount(countWithComma);
-    };
-    fetchViewer();
-  }, []);
+  const { data, error, loading } = useFetch<Viewer>('/persona/count');
+  const countWithComma = data ? data.count.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : 0;
 
   const sortedTitle = TEXT.TITLE.split('\n').map((line) => {
     return (
@@ -56,7 +49,7 @@ export default function PersonaAnalysisPage(): ReactElement {
       <S.Description> {sortedDesc}</S.Description>
 
       <S.CounterDescription>
-        총 <S.Count>{viewerCount}</S.Count>명이 체크해방을 참고했습니다.
+        총 <S.Count>{countWithComma}</S.Count>명이 체크해방을 참고했습니다.
       </S.CounterDescription>
 
       <S.StartButton onClick={handleStartButtonClick}>{TEXT.START}</S.StartButton>

--- a/src/pages/persona/PersonaAnalysisResult.tsx
+++ b/src/pages/persona/PersonaAnalysisResult.tsx
@@ -1,9 +1,7 @@
 import facebookShare from 'api/facebookShare';
 import kakaoShare from 'api/kakaoShare';
-import request from 'api/request';
 import webShare from 'api/webShare';
-import { Persona } from 'entity/persona';
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 
 import * as S from './styled';
@@ -15,23 +13,16 @@ enum TEXT {
 
 export default function PersonaAnalysisResultPage(): ReactElement {
   const shareUrl = 'https://checkhaebang.web.app/';
-  const [persona, setPersona] = useState<Persona>();
-  const fetchPersona = async () => {
-    const { data } = await request.get<Persona>('/persona');
-    setPersona(data);
-  };
-
-  useEffect(() => {
-    fetchPersona();
-  }, []);
+  const queryString = window.location.search;
+  const urlParams = new URLSearchParams(queryString);
 
   return (
     <S.ResultContainer>
       <S.TitleWrapper>
         당신의 자취 유형은
-        <S.UserPersona>{persona ? persona.title : ''}!</S.UserPersona>
+        <S.UserPersona>{urlParams.get('title')}!</S.UserPersona>
       </S.TitleWrapper>
-      <S.PersonaDescription>{persona ? persona.description : ''}</S.PersonaDescription>
+      <S.PersonaDescription>{urlParams.get('description')}</S.PersonaDescription>
 
       <S.ShareButtonDiv>
         <S.ShareButton onClick={() => facebookShare(shareUrl)}>페북</S.ShareButton>

--- a/src/pages/persona/PersonaAnalysisResult.tsx
+++ b/src/pages/persona/PersonaAnalysisResult.tsx
@@ -2,7 +2,7 @@ import facebookShare from 'api/facebookShare';
 import kakaoShare from 'api/kakaoShare';
 import webShare from 'api/webShare';
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import * as S from './styled';
 
@@ -16,6 +16,13 @@ export default function PersonaAnalysisResultPage(): ReactElement {
   const queryString = window.location.search;
   const urlParams = new URLSearchParams(queryString);
 
+  const history = useHistory();
+  const handleGoChecklistButtonClick = () => {
+    history.push('/checklist');
+  };
+  const handleRetestButtonClick = () => {
+    history.push('/persona');
+  };
   return (
     <S.ResultContainer>
       <S.TitleWrapper>
@@ -30,13 +37,10 @@ export default function PersonaAnalysisResultPage(): ReactElement {
         <S.ShareButton onClick={() => webShare('title', shareUrl)}>url</S.ShareButton>
       </S.ShareButtonDiv>
 
-      <Link to='/checklist'>
-        <S.GoChecklistButton>{TEXT.GO_CHECKLIST}</S.GoChecklistButton>
-      </Link>
-
-      <S.RetestButton>
-        <Link to='/persona'>{TEXT.RETEST}</Link>
-      </S.RetestButton>
+      <S.GoChecklistButton onClick={handleGoChecklistButtonClick}>
+        {TEXT.GO_CHECKLIST}
+      </S.GoChecklistButton>
+      <S.RetestButton onClick={handleRetestButtonClick}>{TEXT.RETEST}</S.RetestButton>
     </S.ResultContainer>
   );
 }

--- a/src/pages/persona/styled.ts
+++ b/src/pages/persona/styled.ts
@@ -107,14 +107,18 @@ const Count = styled.span`
   color: ${color.primaryYellow};
 `;
 
-const BackButton = styled.a`
-  margin-top: 18px;
+const BackButton = styled.button`
+  padding-top: 18px;
   text-align: center;
   text-decoration: underline;
   text-underline-position: under;
   font-size: 12px;
   font-weight: bold;
   line-height: 15px;
+  background-color: transparent;
+  border: none;
+  display: flex;
+  margin: auto;
 `;
 
 const CloseButton = styled.button`

--- a/src/pages/persona/styled.ts
+++ b/src/pages/persona/styled.ts
@@ -79,7 +79,7 @@ const ShareButton = styled.button`
   background-color: ${color.primaryDullPurple};
 `;
 
-const RetestButton = styled.div`
+const RetestButton = styled.button`
   margin-top: 18px;
   text-align: center;
   text-decoration: underline;
@@ -87,6 +87,8 @@ const RetestButton = styled.div`
   font-size: 12px;
   font-weight: bold;
   line-height: 15px;
+  border: none;
+  background-color: transparent;
 `;
 
 const CounterDescription = styled.button`
@@ -108,7 +110,6 @@ const Count = styled.span`
 `;
 
 const BackButton = styled.button`
-  padding-top: 18px;
   text-align: center;
   text-decoration: underline;
   text-underline-position: under;
@@ -118,7 +119,7 @@ const BackButton = styled.button`
   background-color: transparent;
   border: none;
   display: flex;
-  margin: auto;
+  margin: 14px auto;
 `;
 
 const CloseButton = styled.button`

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -1,6 +1,7 @@
 import request from 'api/request';
 import Icon from 'components/icon';
-import { Choice, Persona, PersonaQuestion, Questions } from 'entity/persona';
+import { Choice, Persona, PersonaQuestion } from 'entity/persona';
+import { QuestionsResponse } from 'entity/response';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -24,7 +25,7 @@ export default function PersonaQuestionPage(): ReactElement {
 
   const [question, setQuestion] = useState<PersonaQuestion[]>([]);
   const fetchQuestion = async () => {
-    const { data } = await request.get<Questions>('/persona/questions');
+    const { data } = await request.get<QuestionsResponse>('/persona/questions');
     setQuestion(data.questions);
   };
 

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -9,7 +9,7 @@ import Card from './card';
 import Loading from './loading';
 import * as S from './styled';
 
-interface State {
+interface QuestionsState {
   currentIdx: number;
   answer: number[];
   isLoading: boolean;
@@ -23,21 +23,25 @@ interface Choices {
 export default function PersonaQuestionPage(): ReactElement {
   const history = useHistory();
 
-  const [question, setQuestion] = useState<PersonaQuestion[]>([]);
+  const [questions, setQuestions] = useState<PersonaQuestion[]>([]);
   const fetchQuestion = async () => {
     const { data } = await request.get<QuestionsResponse>('/persona/questions');
-    setQuestion(data.questions);
+    setQuestions(data.questions);
   };
 
   useEffect(() => {
     fetchQuestion();
   }, []);
 
-  const [state, setState] = useState<State>({ currentIdx: 0, answer: [], isLoading: false });
+  const [questionsState, setQuestionsState] = useState<QuestionsState>({
+    currentIdx: 0,
+    answer: [],
+    isLoading: false,
+  });
 
   const fetchAnswer = async () => {
     const params = new URLSearchParams();
-    state.answer.forEach((answer: number) => {
+    questionsState.answer.forEach((answer: number) => {
       params.append('check_answers', answer.toString());
     });
 
@@ -52,42 +56,44 @@ export default function PersonaQuestionPage(): ReactElement {
   };
 
   useEffect(() => {
-    if (state.isLoading) {
+    if (questionsState.isLoading) {
       fetchAnswer();
     }
-  }, [state]);
+  }, [questionsState]);
 
-  const { title, choices }: Choices = question[state.currentIdx]
-    ? question[state.currentIdx]
+  const { title, choices }: Choices = questions[questionsState.currentIdx]
+    ? questions[questionsState.currentIdx]
     : { title: '', choices: [{ uid: 0, question_id: 0, contents: '', category: 0 }] };
 
   const questionNum =
-    state.currentIdx + 1 < 10 ? '0' + (state.currentIdx + 1).toString() : state.currentIdx + 1;
-  const progressVal = (100 / question.length) * (state.currentIdx + 1);
+    questionsState.currentIdx + 1 < 10
+      ? '0' + (questionsState.currentIdx + 1).toString()
+      : questionsState.currentIdx + 1;
+  const progressVal = (100 / questions.length) * (questionsState.currentIdx + 1);
 
   const handleCardClick = (index: number) => {
-    if (state.currentIdx == question.length - 1) {
-      setState({
-        currentIdx: state.currentIdx + 1,
-        answer: [...state.answer, choices[index].uid],
+    if (questionsState.currentIdx == questions.length - 1) {
+      setQuestionsState({
+        currentIdx: questionsState.currentIdx + 1,
+        answer: [...questionsState.answer, choices[index].uid],
         isLoading: true,
       });
     } else {
-      setState({
-        currentIdx: state.currentIdx + 1,
-        answer: [...state.answer, choices[index].uid],
+      setQuestionsState({
+        currentIdx: questionsState.currentIdx + 1,
+        answer: [...questionsState.answer, choices[index].uid],
         isLoading: false,
       });
     }
   };
 
   const handleBackButtonClick = () => {
-    if (state.currentIdx == 0) {
+    if (questionsState.currentIdx == 0) {
       history.push('/persona');
     } else {
-      setState({
-        currentIdx: state.currentIdx - 1,
-        answer: state.answer.slice(0, state.answer.length - 1),
+      setQuestionsState({
+        currentIdx: questionsState.currentIdx - 1,
+        answer: questionsState.answer.slice(0, questionsState.answer.length - 1),
         isLoading: false,
       });
     }
@@ -103,7 +109,7 @@ export default function PersonaQuestionPage(): ReactElement {
         onClick={() => handleCardClick(index)}></Card>
     );
   });
-  if (state.isLoading) {
+  if (questionsState.isLoading) {
     return <Loading />;
   }
   return (

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -67,19 +67,12 @@ export default function PersonaQuestionPage(): ReactElement {
   const progressVal = (100 / questions.length) * (questionsState.currentIdx + 1);
 
   const handleCardClick = (index: number) => {
-    if (questionsState.currentIdx == questions.length - 1) {
-      setQuestionsState({
-        currentIdx: questionsState.currentIdx + 1,
-        answer: [...questionsState.answer, choices[index].uid],
-        isLoading: true,
-      });
-    } else {
-      setQuestionsState({
-        currentIdx: questionsState.currentIdx + 1,
-        answer: [...questionsState.answer, choices[index].uid],
-        isLoading: false,
-      });
-    }
+    const loadingFlag = questionsState.currentIdx == questions.length - 1 ? true : false;
+    setQuestionsState({
+      currentIdx: questionsState.currentIdx + 1,
+      answer: [...questionsState.answer, choices[index].uid],
+      isLoading: loadingFlag,
+    });
   };
 
   const handleBackButtonClick = () => {

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -107,9 +107,12 @@ export default function PersonaQuestionPage(): ReactElement {
   }
   return (
     <S.Container>
-      <S.BackButton onClick={handleBackButtonClick}>
-        <Icon name='NAVIGATION_BACKWARD' size='16' />
-      </S.BackButton>
+      <S.Header>
+        <S.BackButton>
+          <Icon name='NAVIGATION_BACKWARD' size='16' />
+        </S.BackButton>
+        <Icon name='TITLE_LOGO' opacity='0.6' />
+      </S.Header>
 
       <S.TitleDiv>
         {questionNum}

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -108,7 +108,7 @@ export default function PersonaQuestionPage(): ReactElement {
   return (
     <S.Container>
       <S.Header>
-        <S.BackButton>
+        <S.BackButton onClick={handleBackButtonClick}>
           <Icon name='NAVIGATION_BACKWARD' size='16' />
         </S.BackButton>
         <Icon name='TITLE_LOGO' opacity='0.6' />

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -45,14 +45,9 @@ export default function PersonaQuestionPage(): ReactElement {
       params.append('check_answers', answer.toString());
     });
 
-    await request
-      .get<Persona>('/persona', {
-        params: params,
-      })
-      .then((res) => {
-        const data = res.data;
-        history.push(`/persona/result?title=${data.title}&description=${data.description}`);
-      });
+    const res = await request.get<Persona>('/persona', { params: params });
+    const data = res.data;
+    history.push(`/persona/result?title=${data.title}&description=${data.description}`);
   };
 
   useEffect(() => {

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -109,10 +109,10 @@ export default function PersonaQuestionPage(): ReactElement {
         onClick={() => handleCardClick(index)}></Card>
     );
   });
-  if (questionsState.isLoading) {
-    return <Loading />;
-  }
-  return (
+
+  return questionsState.isLoading ? (
+    <Loading />
+  ) : (
     <S.Container>
       <S.Header>
         <S.BackButton onClick={handleBackButtonClick}>

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -1,6 +1,6 @@
 import request from 'api/request';
 import Icon from 'components/icon';
-import { Choice, PersonaQuestion, Questions } from 'entity/persona';
+import { Choice, Persona, PersonaQuestion, Questions } from 'entity/persona';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -33,9 +33,26 @@ export default function PersonaQuestionPage(): ReactElement {
   }, []);
 
   const [state, setState] = useState<State>({ currentIdx: 0, answer: [], isLoading: false });
+
+  const fetchAnswer = async () => {
+    const params = new URLSearchParams();
+    state.answer.forEach((answer: number) => {
+      params.append('check_answers', answer.toString());
+    });
+
+    await request
+      .get<Persona>('/persona', {
+        params: params,
+      })
+      .then((res) => {
+        const data = res.data;
+        history.push(`/persona/result?title=${data.title}&description=${data.description}`);
+      });
+  };
+
   useEffect(() => {
     if (state.isLoading) {
-      // fetchAnswer();
+      fetchAnswer();
     }
   }, [state]);
 
@@ -69,7 +86,7 @@ export default function PersonaQuestionPage(): ReactElement {
     } else {
       setState({
         currentIdx: state.currentIdx - 1,
-        answer: state.answer.splice(state.answer.length - 1, 1),
+        answer: state.answer.slice(0, state.answer.length - 1),
         isLoading: false,
       });
     }
@@ -85,7 +102,6 @@ export default function PersonaQuestionPage(): ReactElement {
         onClick={() => handleCardClick(index)}></Card>
     );
   });
-
   if (state.isLoading) {
     return <Loading />;
   }

--- a/src/pages/question/PersonaQuestion.tsx
+++ b/src/pages/question/PersonaQuestion.tsx
@@ -126,7 +126,7 @@ export default function PersonaQuestionPage(): ReactElement {
         <br />
         {title}
       </S.TitleDiv>
-      <S.CardDiv>{cardList}</S.CardDiv>
+      <S.CardsWrapper>{cardList}</S.CardsWrapper>
       <S.ProgressContainer>
         <S.ProgressComplete barWidth={progressVal}></S.ProgressComplete>
       </S.ProgressContainer>

--- a/src/pages/question/card/styled.ts
+++ b/src/pages/question/card/styled.ts
@@ -4,18 +4,23 @@ import color from 'styles/color';
 const CardWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: center;
   align-items: center;
-  padding: 16px;
-  height: 178px;
-  border: 4px solid ${color.basicBlack};
+  margin-bottom: 20px;
+  padding: 20px;
+  width: 100%;
+  height: 83px;
+  border: solid 1px ${color.grayscale29};
+  border-radius: 6px;
   background-color: ${color.basicWhite};
-  box-shadow: 10px 5px 0 ${color.basicBlack};
+  box-shadow: 1px 1px 0 2px ${color.grayscale29};
 `;
 const CardContent = styled.p`
   font-size: 16px;
+  font-weight: bold;
   line-height: 21px;
-  color: ${color.basicBlack};
+  color: ${color.primaryDeepDarkBlue};
+  text-align: center;
 `;
 
 export { CardWrapper, CardContent };

--- a/src/pages/question/card/styled.ts
+++ b/src/pages/question/card/styled.ts
@@ -8,14 +8,14 @@ const CardWrapper = styled.div`
   align-items: center;
   padding: 16px;
   height: 178px;
-  border: none;
-  border-radius: 6px;
-  background-color: ${color.primaryDullPurple};
+  border: 4px solid ${color.basicBlack};
+  background-color: ${color.basicWhite};
+  box-shadow: 10px 5px 0 ${color.basicBlack};
 `;
 const CardContent = styled.p`
   font-size: 16px;
   line-height: 21px;
-  color: ${color.basicWhite};
+  color: ${color.basicBlack};
 `;
 
 export { CardWrapper, CardContent };

--- a/src/pages/question/styled.ts
+++ b/src/pages/question/styled.ts
@@ -22,12 +22,13 @@ const TitleDiv = styled.div`
 `;
 
 const CardDiv = styled.div`
-  display: grid;
-  grid-template-rows: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  gap: 16px 16px;
-  height: 352px;
-  margin-top: 16px;
+  height: 272px;
+  margin-top: 6px;
+  padding: 40px 0 46px;
 `;
 
 const ProgressContainer = styled.div`

--- a/src/pages/question/styled.ts
+++ b/src/pages/question/styled.ts
@@ -31,7 +31,7 @@ const TitleDiv = styled.div`
   line-height: 29px;
 `;
 
-const CardDiv = styled.div`
+const CardsWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -60,4 +60,12 @@ const ProgressComplete = styled.div<{ barWidth: number }>`
   transition: width 0.5s ease-in-out;
 `;
 
-export { Container, Header, BackButton, TitleDiv, CardDiv, ProgressContainer, ProgressComplete };
+export {
+  Container,
+  Header,
+  BackButton,
+  TitleDiv,
+  CardsWrapper,
+  ProgressContainer,
+  ProgressComplete,
+};

--- a/src/pages/question/styled.ts
+++ b/src/pages/question/styled.ts
@@ -23,7 +23,7 @@ const TitleDiv = styled.div`
 
 const CardDiv = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
   align-items: center;
   gap: 16px 16px;
   height: 352px;

--- a/src/pages/question/styled.ts
+++ b/src/pages/question/styled.ts
@@ -9,8 +9,18 @@ const Container = styled.div`
   background-color: ${color.grayscalef9};
 `;
 
+const Header = styled.div`
+  display: flex;
+  flex-directions: column;
+  justify-content: center;
+  align-items: center;
+  height: 46px;
+  padding-top: 15px;
+`;
+
 const BackButton = styled.a`
-  margin-top: 45px;
+  position: absolute;
+  left: 24px;
 `;
 
 const TitleDiv = styled.div`
@@ -50,4 +60,4 @@ const ProgressComplete = styled.div<{ barWidth: number }>`
   transition: width 0.5s ease-in-out;
 `;
 
-export { Container, BackButton, TitleDiv, CardDiv, ProgressContainer, ProgressComplete };
+export { Container, Header, BackButton, TitleDiv, CardDiv, ProgressContainer, ProgressComplete };


### PR DESCRIPTION
- 디자인 변경에 따라 card 정렬, header 로고 추가했습니다.
- personaAnalysisPage 에서 login화면으로 바로 넘어가는 버튼 기능 추가했습니다.
- `persona` , `persona/count`, `persona/questions` api 연결했습니다.
- 진단을 끝내고 result 페이지로 넘어갈 때, 로그인이 안되어 있어도 가져올 수 있게 해야하므로 기존에 GET 요청으로 persona 정보를 가져오던 것에서 query로 정보를 받아오는 방식으로 변경했습니다.