### PR TITLE
fix: 🐛 dot keyframe 제거

### DIFF
--- a/src/components/loading/index.tsx
+++ b/src/components/loading/index.tsx
@@ -10,10 +10,7 @@ export default function Loading({ image, text }: LoadingProps) {
   return (
     <S.Container>
       <img src={image}></img>
-      <S.LoadingText>
-        {text}
-        <S.Dot />
-      </S.LoadingText>
+      <S.LoadingText>{text}...</S.LoadingText>
     </S.Container>
   );
 }


### PR DESCRIPTION
styled component의 keyframes api가 web-only api이다 보니 모바일에서 마침표(.) 로 보이는 이슈가 있어서
애니메이션 제거 후 ... 으로 대응할 수 있도록 했습니다.